### PR TITLE
adding .onAttach for smooth data loading

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,4 @@
+.onAttach <- function(libname, pkgname)
+{
+  suppressPackageStartupMessages(library(igraph, quietly = TRUE, verbose = FALSE, warn.conflicts = FALSE))
+}


### PR DESCRIPTION
When `igraphdata` is presently loaded. The data does not look nice when the library is called without `igraph`.  I added a `zzz.R` file and an `.onAttach` function.

## `Without .onAttach`

![Screenshot 2024-11-14 200949](https://github.com/user-attachments/assets/0b28f113-7629-4fee-a019-13398dcc8198)

## With `.onAttach`
This is a fix:

![image](https://github.com/user-attachments/assets/e1e78e8d-9415-4751-ba0c-dd8108dd10b4)


Let me know if this is helpful or not.
