### PR TITLE
docs: add reference for lesmis

### DIFF
--- a/R/files.R
+++ b/R/files.R
@@ -5,6 +5,8 @@
 #'
 #' @return A string indicating an absolute path to a file.
 #' @name lesmis
+#' @references D. E. Knuth, The Stanford GraphBase: A Platform for Combinatorial Computing, Addison-Wesley, Reading, MA (1993).
+#' \url{https://www-cs-faculty.stanford.edu/~knuth/sgb.html}
 #' @export
 lesmis_gml <- function() {
   system.file("files/lesmis.gml", package = "igraphdata", mustWork = TRUE)

--- a/man/lesmis.Rd
+++ b/man/lesmis.Rd
@@ -20,3 +20,7 @@ A string indicating an absolute path to a file.
 Functions that return paths to example files of the "Les Miserables" example network,
 in the GML, GraphML or Pajek format.
 }
+\references{
+D. E. Knuth, The Stanford GraphBase: A Platform for Combinatorial Computing, Addison-Wesley, Reading, MA (1993).
+\url{https://www-cs-faculty.stanford.edu/~knuth/sgb.html}
+}


### PR DESCRIPTION
The DOI at https://dl.acm.org/doi/book/10.1145/164984 does not work

Part of #31